### PR TITLE
Add action to restore D365FO NuGet packages from FSC storage

### DIFF
--- a/FSC-PS-Helper.ps1
+++ b/FSC-PS-Helper.ps1
@@ -704,6 +704,30 @@ function GenerateSolution {
 
     Set-Location $PSScriptRoot
 }
+
+function GeneratePackagesConfig
+{
+    [CmdletBinding()]
+    param (
+        [string]$DynamicsVersion
+    )
+
+    Foreach($version in Get-Versions)
+    {
+        if($version.version -eq $DynamicsVersion)
+        {
+            $PlatformVersion = $version.data.PlatformVersion
+            $ApplicationVersion = $version.data.AppVersion
+        }
+    }
+
+    $NugetFolderPath =  Join-Path $PSScriptRoot 'NewBuild'
+    $PackagesConfigFileName = 'packages.config'
+    $NewPackagesFile = Join-Path $NugetFolderPath $PackagesConfigFileName
+    $tempFile = (Get-Content $PackagesConfigFileName).Replace('PlatformVersion', $PlatformVersion).Replace('ApplicationVersion', $ApplicationVersion)
+    Set-Content $NewPackagesFile $tempFile
+}
+
 function Update-RetailSDK
 {
     [CmdletBinding()]

--- a/FSC-PS-Helper.ps1
+++ b/FSC-PS-Helper.ps1
@@ -724,6 +724,7 @@ function GeneratePackagesConfig
     }
 
     $NugetFolderPath =  Join-Path $PSScriptRoot 'NewBuild'
+    New-Item -ItemType Directory -Path $NugetFolderPath
     $PackagesConfigFileName = 'packages.config'
     $NewPackagesFile = Join-Path $NugetFolderPath $PackagesConfigFileName
     $tempFile = (Get-Content $PackagesConfigFileName).Replace('PlatformVersion', $PlatformVersion).Replace('ApplicationVersion', $ApplicationVersion)

--- a/FSC-PS-Helper.ps1
+++ b/FSC-PS-Helper.ps1
@@ -673,7 +673,34 @@ function GenerateSolution {
         GenerateProjectFile -ModelName $project.Name -ProjectGuid $project.Value -MetadataPath $MetadataPath 
     }
 
+    $parameters = @{
+        DynamicsVersion = $DynamicsVersion
+        NugetFeedName = $NugetFeedName
+        NugetSourcePath = $NugetSourcePath
+        NugetFolderPath = $NugetFolderPath
+    }
+    GeneratePackagesConfig @parameters
+}
+
+function GeneratePackagesConfig
+{
+    [CmdletBinding()]
+    param (
+        [string]$DynamicsVersion,
+        [string]$NugetFeedName = '',
+        [string]$NugetSourcePath = '',
+        [string]$NugetFolderPath = ''
+    )
+
+    if (-not $NugetFolderPath) {
+        $NugetFolderPath =  Join-Path $PSScriptRoot 'NewBuild'
+    }
+    if (-not (Test-Path -Path $NugetFolderPath)) {
+        New-Item -ItemType Directory -Path $NugetFolderPath
+    }
+
     Set-Location $PSScriptRoot\Build
+
     #generate nuget.config
     $NugetConfigFileName = 'nuget.config'
     $NewNugetFile = Join-Path $NugetFolderPath $NugetConfigFileName
@@ -686,7 +713,6 @@ function GenerateSolution {
     }
     Set-Content $NewNugetFile $tempFile
 
-
     Foreach($version in Get-Versions)
     {
         if($version.version -eq $DynamicsVersion)
@@ -697,41 +723,6 @@ function GenerateSolution {
     }
 
     #generate packages.config
-    $PackagesConfigFileName = 'packages.config'
-    $NewPackagesFile = Join-Path $NugetFolderPath $PackagesConfigFileName
-    $tempFile = (Get-Content $PackagesConfigFileName).Replace('PlatformVersion', $PlatformVersion).Replace('ApplicationVersion', $ApplicationVersion)
-    Set-Content $NewPackagesFile $tempFile
-
-    Set-Location $PSScriptRoot
-}
-
-function GeneratePackagesConfig
-{
-    [CmdletBinding()]
-    param (
-        [string]$DynamicsVersion
-    )
-
-    Set-Location $PSScriptRoot\Build
-
-    $NugetFolderPath =  Join-Path $PSScriptRoot 'NewBuild'
-    New-Item -ItemType Directory -Path $NugetFolderPath
-
-    #generate nuget.config
-    $NugetConfigFileName = 'nuget.config'
-    $NewNugetFile = Join-Path $NugetFolderPath $NugetConfigFileName
-    $tempFile = (Get-Content $NugetConfigFileName).Replace('<add key="NugetFeedName" value="NugetSourcePath" />', '')
-    Set-Content $NewNugetFile $tempFile
-
-    #generate packages.config
-    Foreach($version in Get-Versions)
-    {
-        if($version.version -eq $DynamicsVersion)
-        {
-            $PlatformVersion = $version.data.PlatformVersion
-            $ApplicationVersion = $version.data.AppVersion
-        }
-    }
     $PackagesConfigFileName = 'packages.config'
     $NewPackagesFile = Join-Path $NugetFolderPath $PackagesConfigFileName
     $tempFile = (Get-Content $PackagesConfigFileName).Replace('PlatformVersion', $PlatformVersion).Replace('ApplicationVersion', $ApplicationVersion)

--- a/FSC-PS-Helper.ps1
+++ b/FSC-PS-Helper.ps1
@@ -714,6 +714,22 @@ function GeneratePackagesConfig
 
     Set-Location $PSScriptRoot\Build
 
+    $NugetFolderPath =  Join-Path $PSScriptRoot 'NewBuild'
+    New-Item -ItemType Directory -Path $NugetFolderPath
+
+    #generate nuget.config
+    $NugetConfigFileName = 'nuget.config'
+    $NewNugetFile = Join-Path $NugetFolderPath $NugetConfigFileName
+    if($NugetFeedName)
+    {
+        $tempFile = (Get-Content $NugetConfigFileName).Replace('NugetFeedName', $NugetFeedName).Replace('NugetSourcePath', $NugetSourcePath)
+    }
+    else {
+        $tempFile = (Get-Content $NugetConfigFileName).Replace('<add key="NugetFeedName" value="NugetSourcePath" />', '')
+    }
+    Set-Content $NewNugetFile $tempFile
+
+    #generate packages.config
     Foreach($version in Get-Versions)
     {
         if($version.version -eq $DynamicsVersion)
@@ -722,9 +738,6 @@ function GeneratePackagesConfig
             $ApplicationVersion = $version.data.AppVersion
         }
     }
-
-    $NugetFolderPath =  Join-Path $PSScriptRoot 'NewBuild'
-    New-Item -ItemType Directory -Path $NugetFolderPath
     $PackagesConfigFileName = 'packages.config'
     $NewPackagesFile = Join-Path $NugetFolderPath $PackagesConfigFileName
     $tempFile = (Get-Content $PackagesConfigFileName).Replace('PlatformVersion', $PlatformVersion).Replace('ApplicationVersion', $ApplicationVersion)

--- a/FSC-PS-Helper.ps1
+++ b/FSC-PS-Helper.ps1
@@ -712,6 +712,8 @@ function GeneratePackagesConfig
         [string]$DynamicsVersion
     )
 
+    Set-Location $PSScriptRoot\Build
+
     Foreach($version in Get-Versions)
     {
         if($version.version -eq $DynamicsVersion)
@@ -726,6 +728,8 @@ function GeneratePackagesConfig
     $NewPackagesFile = Join-Path $NugetFolderPath $PackagesConfigFileName
     $tempFile = (Get-Content $PackagesConfigFileName).Replace('PlatformVersion', $PlatformVersion).Replace('ApplicationVersion', $ApplicationVersion)
     Set-Content $NewPackagesFile $tempFile
+
+    Set-Location $PSScriptRoot
 }
 
 function Update-RetailSDK

--- a/FSC-PS-Helper.ps1
+++ b/FSC-PS-Helper.ps1
@@ -720,13 +720,7 @@ function GeneratePackagesConfig
     #generate nuget.config
     $NugetConfigFileName = 'nuget.config'
     $NewNugetFile = Join-Path $NugetFolderPath $NugetConfigFileName
-    if($NugetFeedName)
-    {
-        $tempFile = (Get-Content $NugetConfigFileName).Replace('NugetFeedName', $NugetFeedName).Replace('NugetSourcePath', $NugetSourcePath)
-    }
-    else {
-        $tempFile = (Get-Content $NugetConfigFileName).Replace('<add key="NugetFeedName" value="NugetSourcePath" />', '')
-    }
+    $tempFile = (Get-Content $NugetConfigFileName).Replace('<add key="NugetFeedName" value="NugetSourcePath" />', '')
     Set-Content $NewNugetFile $tempFile
 
     #generate packages.config

--- a/RestoreFSCNuget/RestoreFSCNuget.ps1
+++ b/RestoreFSCNuget/RestoreFSCNuget.ps1
@@ -22,6 +22,8 @@ try {
     OutputInfo "======================================== Nuget install packages"
 
     GeneratePackagesConfig -DynamicsVersion $DynamicsVersion
+    $tree = tree /F
+    Write-Output $tree
     nuget restore -PackagesDirectory ..\NuGets
     Write-Output "::endgroup::"
 }

--- a/RestoreFSCNuget/RestoreFSCNuget.ps1
+++ b/RestoreFSCNuget/RestoreFSCNuget.ps1
@@ -1,0 +1,31 @@
+Param(
+    [Parameter(HelpMessage = "DynamicsVersion", Mandatory = $true)]
+    [string] $DynamicsVersion
+)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+# IMPORTANT: No code that can fail should be outside the try/catch
+
+try {
+    $helperPath = Join-Path -Path $PSScriptRoot -ChildPath "..\FSC-PS-Helper.ps1" -Resolve
+    . $helperPath
+
+    Write-Output "::group::Download default NuGet packages"
+    OutputInfo "======================================== Download default NuGet"
+
+    Update-FSCNuGet -sdkVersion $DynamicsVersion
+    Write-Output "::endgroup::"
+
+    Write-Output "::group::Nuget install packages"
+    OutputInfo "======================================== Nuget install packages"
+
+    nuget restore -PackagesDirectory ..\NuGets
+    Write-Output "::endgroup::"
+}
+catch {
+  OutputError -message $_.Exception.Message
+}
+finally
+{
+  OutputInfo "Execution is done."
+}

--- a/RestoreFSCNuget/RestoreFSCNuget.ps1
+++ b/RestoreFSCNuget/RestoreFSCNuget.ps1
@@ -10,6 +10,8 @@ try {
     $helperPath = Join-Path -Path $PSScriptRoot -ChildPath "..\FSC-PS-Helper.ps1" -Resolve
     . $helperPath
 
+    installModules @("AZ.Storage")
+
     Write-Output "::group::Download default NuGet packages"
     OutputInfo "======================================== Download default NuGet"
 

--- a/RestoreFSCNuget/RestoreFSCNuget.ps1
+++ b/RestoreFSCNuget/RestoreFSCNuget.ps1
@@ -23,10 +23,7 @@ try {
     Write-Output "::group::Nuget install packages"
     OutputInfo "======================================== Nuget install packages"
 
-    tree /F
     GeneratePackagesConfig -DynamicsVersion $DynamicsVersion 
-    $tree = tree /F
-    Write-Output $tree
     Set-Location NewBuild
     nuget restore -PackagesDirectory $PackagesDirectory
     Write-Output "::endgroup::"

--- a/RestoreFSCNuget/RestoreFSCNuget.ps1
+++ b/RestoreFSCNuget/RestoreFSCNuget.ps1
@@ -21,6 +21,7 @@ try {
     Write-Output "::group::Nuget install packages"
     OutputInfo "======================================== Nuget install packages"
 
+    GeneratePackagesConfig -DynamicsVersion $DynamicsVersion
     nuget restore -PackagesDirectory ..\NuGets
     Write-Output "::endgroup::"
 }

--- a/RestoreFSCNuget/RestoreFSCNuget.ps1
+++ b/RestoreFSCNuget/RestoreFSCNuget.ps1
@@ -1,6 +1,8 @@
 Param(
     [Parameter(HelpMessage = "DynamicsVersion", Mandatory = $true)]
-    [string] $DynamicsVersion
+    [string] $DynamicsVersion,
+    [Parameter(HelpMessage = "PackagesDirectory", Mandatory = $true)]
+    [string] $PackagesDirectory
 )
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 2.0
@@ -21,10 +23,12 @@ try {
     Write-Output "::group::Nuget install packages"
     OutputInfo "======================================== Nuget install packages"
 
-    GeneratePackagesConfig -DynamicsVersion $DynamicsVersion
+    tree /F
+    GeneratePackagesConfig -DynamicsVersion $DynamicsVersion 
     $tree = tree /F
     Write-Output $tree
-    nuget restore -PackagesDirectory ..\NuGets
+    Set-Location NewBuild
+    nuget restore -PackagesDirectory $PackagesDirectory
     Write-Output "::endgroup::"
 }
 catch {

--- a/RestoreFSCNuget/action.yaml
+++ b/RestoreFSCNuget/action.yaml
@@ -1,0 +1,12 @@
+name: Restore Nugets from FSC storage
+author: Florian Hopfner
+inputs:
+  version:
+    description: The Dynamics Application Version
+    required: true
+runs:
+  using: composite
+  steps:
+    - run: try { ${{ github.action_path }}/RestoreFSCNuget.ps1 -DynamicsVersion '${{ inputs.version }}' } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message))"; exit 1 }
+      id: restorefscnuget
+      shell: PowerShell

--- a/RestoreFSCNuget/action.yaml
+++ b/RestoreFSCNuget/action.yaml
@@ -4,9 +4,12 @@ inputs:
   version:
     description: The Dynamics Application Version
     required: true
+  packagesDirectory:
+    description: The directory where the packages should be restored to
+    required: true
 runs:
   using: composite
   steps:
-    - run: try { ${{ github.action_path }}/RestoreFSCNuget.ps1 -DynamicsVersion '${{ inputs.version }}' } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message))"; exit 1 }
+    - run: try { ${{ github.action_path }}/RestoreFSCNuget.ps1 -DynamicsVersion '${{ inputs.version }}' -PackagesDirectory '${{ inputs.packagesDirectory }}' } catch { Write-Host "::Error::Unexpected error when running action ($($_.Exception.Message))"; exit 1 }
       id: restorefscnuget
       shell: PowerShell


### PR DESCRIPTION
The RunPipeline action internally downloads and restores the D365FO NuGet packages required for a build.

This pull requests adds a RestoreFSCNuget action that does just that. This enables use of the NuGet packages for other scenarios.
One possible use case is to build a .NET project that depends on assemblies that are part of those NuGet packages.

See https://github.com/ameyer505/D365FOAdminToolkit/pull/12 for further information and motivation for this pr.